### PR TITLE
fix typo: five OSes in the list

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -44,7 +44,7 @@ Status
 Supported Platforms.
 --------------------
 
-Myrddin currently compiles for x86-64. It runs on four OSes at the moment:
+Myrddin currently compiles for x86-64. It runs on five OSes at the moment:
 
 - Linux
 - OSX


### PR DESCRIPTION
The index of the site says Myrddin compiles on four OSes, but the list of OSes includes five.  This pull request updates the text to match the number of OSes in the list.