### PR TITLE
remove obsolete ".use"

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -272,8 +272,8 @@ statement, like `use package_name`, to your code. This will allow you to access
 `package_name.symbol`.
 
 To import symbols from a file within the same directory as your source code,
-add `use "filename.use"`. The package name that is brought in to your namespace
-is determined by the `pkg` spec within the source file being imported.
+add `use "filename"`. The package name that is brought in to your namespace is
+determined by the `pkg` spec within the source file being imported.
 
 If two use statements load the same package (e.g., two local files export symbols
 for the `foo` package), then the packages will be merged.


### PR DESCRIPTION
    use "filename.use" -> use "filename"